### PR TITLE
fix: MIS-3327 remove requirement on vesselIMONumber and add requirement on transportEventTypeCode

### DIFF
--- a/api_files/maersk_track_and_trace.yaml
+++ b/api_files/maersk_track_and_trace.yaml
@@ -434,8 +434,6 @@ components:
           documentReferenceValue: 85943567-eedb-98d3-f4ed-aed697474ed4
     Vessel:
       type: object
-      required:
-        - vesselIMONumber
       properties:
         vesselIMONumber:
           description: The unique reference for a registered Vessel. The reference is the International Maritime Organisation (IMO) number, also sometimes known as the Lloyd's register code, which does not change during the lifetime of the vessel
@@ -878,7 +876,7 @@ components:
             documentReferences:
               $ref: '#/components/schemas/DocumentReferences'
           required:
-            - transportEventType
+            - transportEventTypeCode
         - type: object
           properties:
             transportCall:

--- a/maersk/docs/EventsEventsInner.md
+++ b/maersk/docs/EventsEventsInner.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **DocumentTypeCode** | **string** | The code to identify the type of information documentID points to. Can be one of the following values * CBR (Carrier Booking Request Reference) * BKG (Booking) * SHI (Shipping Instruction) * SRM (Shipment Release Message) * TRD (Transport Document) * ARN (Arrival Notice) * VGM (Verified Gross Mass) * CAS (Cargo Survey) * CUS (Customs Inspection) * DGD (Dangerous Goods Declaration) * OOG (Out of Gauge)  | 
 **DocumentID** | **string** | The ID of the object defined by the Shipment Information Type. In some cases this is a UUID; in other cases this is a string.  | 
 **Reason** | Pointer to **string** | Reason field in a Shipment event. This field can be used to explain why a specific event has been sent. | [optional] 
-**TransportEventTypeCode** | Pointer to **string** | Identifier for type of Transport event - ARRI (Arrived) - DEPA (Departed)  | [optional] 
+**TransportEventTypeCode** | **string** | Identifier for type of Transport event - ARRI (Arrived) - DEPA (Departed)  | 
 **DelayReasonCode** | Pointer to **string** | Reason code for the delay. The SMDG-Delay-Reason-Codes are used for this attribute. The code list can be found at http://www.smdg.org/smdg-code-lists/  | [optional] 
 **ChangeRemark** | Pointer to **string** | Free text information provided by the vessel operator regarding the reasons for the change in schedule and/or plans to mitigate schedule slippage. | [optional] 
 **DocumentReferences** | Pointer to [**[]DocumentReferencesInner**](DocumentReferencesInner.md) | An optional list of key-value (documentReferenceType-documentReferenceValue) pairs representing links to objects relevant to the event. The documentReferenceType-field is used to describe where the documentReferenceValue-field is pointing to. | [optional] 
@@ -30,7 +30,7 @@ Name | Type | Description | Notes
 
 ### NewEventsEventsInner
 
-`func NewEventsEventsInner(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, shipmentEventTypeCode string, documentTypeCode string, documentID string, transportCall TransportCall, emptyIndicatorCode string, ) *EventsEventsInner`
+`func NewEventsEventsInner(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, shipmentEventTypeCode string, documentTypeCode string, documentID string, transportEventTypeCode string, transportCall TransportCall, emptyIndicatorCode string, ) *EventsEventsInner`
 
 NewEventsEventsInner instantiates a new EventsEventsInner object
 This constructor will assign default values to properties that have it defined,
@@ -279,11 +279,6 @@ and a boolean to check if the value has been set.
 
 SetTransportEventTypeCode sets TransportEventTypeCode field to given value.
 
-### HasTransportEventTypeCode
-
-`func (o *EventsEventsInner) HasTransportEventTypeCode() bool`
-
-HasTransportEventTypeCode returns a boolean if a field has been set.
 
 ### GetDelayReasonCode
 

--- a/maersk/docs/TransportEvent.md
+++ b/maersk/docs/TransportEvent.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **EventCreatedDateTime** | **time.Time** | The UTC timestamp of when the event was created. | 
 **EventClassifierCode** | **string** | Code for the event classifier, either PLN, ACT or EST. * PLN - Planned * ACT - Actual * EST - Estimated  | 
 **References** | Pointer to [**[]EventReferencesInner**](EventReferencesInner.md) | References provided by the shipper or freight forwarder at the time of booking or at the time of providing shipping instruction. Carriers share it back when providing track and trace event updates, some are also printed on the B/L. Customers can use these references to track shipments in their internal systems. | [optional] 
-**TransportEventTypeCode** | Pointer to **string** | Identifier for type of Transport event - ARRI (Arrived) - DEPA (Departed)  | [optional] 
+**TransportEventTypeCode** | **string** | Identifier for type of Transport event - ARRI (Arrived) - DEPA (Departed)  | 
 **DelayReasonCode** | Pointer to **string** | Reason code for the delay. The SMDG-Delay-Reason-Codes are used for this attribute. The code list can be found at http://www.smdg.org/smdg-code-lists/  | [optional] 
 **ChangeRemark** | Pointer to **string** | Free text information provided by the vessel operator regarding the reasons for the change in schedule and/or plans to mitigate schedule slippage. | [optional] 
 **DocumentReferences** | Pointer to [**[]DocumentReferencesInner**](DocumentReferencesInner.md) | An optional list of key-value (documentReferenceType-documentReferenceValue) pairs representing links to objects relevant to the event. The documentReferenceType-field is used to describe where the documentReferenceValue-field is pointing to. | [optional] 
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 
 ### NewTransportEvent
 
-`func NewTransportEvent(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, transportCall TransportCall, ) *TransportEvent`
+`func NewTransportEvent(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, transportEventTypeCode string, transportCall TransportCall, ) *TransportEvent`
 
 NewTransportEvent instantiates a new TransportEvent object
 This constructor will assign default values to properties that have it defined,
@@ -184,11 +184,6 @@ and a boolean to check if the value has been set.
 
 SetTransportEventTypeCode sets TransportEventTypeCode field to given value.
 
-### HasTransportEventTypeCode
-
-`func (o *TransportEvent) HasTransportEventTypeCode() bool`
-
-HasTransportEventTypeCode returns a boolean if a field has been set.
 
 ### GetDelayReasonCode
 

--- a/maersk/docs/Vessel.md
+++ b/maersk/docs/Vessel.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VesselIMONumber** | **string** | The unique reference for a registered Vessel. The reference is the International Maritime Organisation (IMO) number, also sometimes known as the Lloyd&#39;s register code, which does not change during the lifetime of the vessel | 
+**VesselIMONumber** | Pointer to **string** | The unique reference for a registered Vessel. The reference is the International Maritime Organisation (IMO) number, also sometimes known as the Lloyd&#39;s register code, which does not change during the lifetime of the vessel | [optional] 
 **VesselName** | Pointer to **string** | The name of the Vessel given by the Vessel Operator and registered with IMO. | [optional] 
 **VesselFlag** | Pointer to **string** | The flag of the nation whose laws the vessel is registered under. This is the ISO 3166 two-letter country code | [optional] 
 **VesselCallSignNumber** | Pointer to **string** | A unique alphanumeric identity that belongs to the vessel and is assigned by the International Telecommunication Union (ITU). It consists of a three letter alphanumeric prefix that indicates nationality, followed by one to four characters to identify the individual vessel. For instance, vessels registered under Denmark are assigned the prefix ranges 5PA-5QZ, OUAOZZ, and XPA-XPZ. The Call Sign changes whenever a vessel changes its flag. | [optional] 
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 
 ### NewVessel
 
-`func NewVessel(vesselIMONumber string, ) *Vessel`
+`func NewVessel() *Vessel`
 
 NewVessel instantiates a new Vessel object
 This constructor will assign default values to properties that have it defined,
@@ -49,6 +49,11 @@ and a boolean to check if the value has been set.
 
 SetVesselIMONumber sets VesselIMONumber field to given value.
 
+### HasVesselIMONumber
+
+`func (o *Vessel) HasVesselIMONumber() bool`
+
+HasVesselIMONumber returns a boolean if a field has been set.
 
 ### GetVesselName
 

--- a/maersk/model_transport_event.go
+++ b/maersk/model_transport_event.go
@@ -34,7 +34,7 @@ type TransportEvent struct {
 	// References provided by the shipper or freight forwarder at the time of booking or at the time of providing shipping instruction. Carriers share it back when providing track and trace event updates, some are also printed on the B/L. Customers can use these references to track shipments in their internal systems.
 	References []EventReferencesInner `json:"references,omitempty"`
 	// Identifier for type of Transport event - ARRI (Arrived) - DEPA (Departed)
-	TransportEventTypeCode *string `json:"transportEventTypeCode,omitempty"`
+	TransportEventTypeCode string `json:"transportEventTypeCode"`
 	// Reason code for the delay. The SMDG-Delay-Reason-Codes are used for this attribute. The code list can be found at http://www.smdg.org/smdg-code-lists/
 	DelayReasonCode *string `json:"delayReasonCode,omitempty"`
 	// Free text information provided by the vessel operator regarding the reasons for the change in schedule and/or plans to mitigate schedule slippage.
@@ -50,12 +50,13 @@ type _TransportEvent TransportEvent
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTransportEvent(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, transportCall TransportCall) *TransportEvent {
+func NewTransportEvent(eventType string, eventDateTime string, eventCreatedDateTime time.Time, eventClassifierCode string, transportEventTypeCode string, transportCall TransportCall) *TransportEvent {
 	this := TransportEvent{}
 	this.EventType = eventType
 	this.EventDateTime = eventDateTime
 	this.EventCreatedDateTime = eventCreatedDateTime
 	this.EventClassifierCode = eventClassifierCode
+	this.TransportEventTypeCode = transportEventTypeCode
 	this.TransportCall = transportCall
 	return &this
 }
@@ -228,36 +229,28 @@ func (o *TransportEvent) SetReferences(v []EventReferencesInner) {
 	o.References = v
 }
 
-// GetTransportEventTypeCode returns the TransportEventTypeCode field value if set, zero value otherwise.
+// GetTransportEventTypeCode returns the TransportEventTypeCode field value
 func (o *TransportEvent) GetTransportEventTypeCode() string {
-	if o == nil || IsNil(o.TransportEventTypeCode) {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.TransportEventTypeCode
+
+	return o.TransportEventTypeCode
 }
 
-// GetTransportEventTypeCodeOk returns a tuple with the TransportEventTypeCode field value if set, nil otherwise
+// GetTransportEventTypeCodeOk returns a tuple with the TransportEventTypeCode field value
 // and a boolean to check if the value has been set.
 func (o *TransportEvent) GetTransportEventTypeCodeOk() (*string, bool) {
-	if o == nil || IsNil(o.TransportEventTypeCode) {
+	if o == nil {
 		return nil, false
 	}
-	return o.TransportEventTypeCode, true
+	return &o.TransportEventTypeCode, true
 }
 
-// HasTransportEventTypeCode returns a boolean if a field has been set.
-func (o *TransportEvent) HasTransportEventTypeCode() bool {
-	if o != nil && !IsNil(o.TransportEventTypeCode) {
-		return true
-	}
-
-	return false
-}
-
-// SetTransportEventTypeCode gets a reference to the given string and assigns it to the TransportEventTypeCode field.
+// SetTransportEventTypeCode sets field value
 func (o *TransportEvent) SetTransportEventTypeCode(v string) {
-	o.TransportEventTypeCode = &v
+	o.TransportEventTypeCode = v
 }
 
 // GetDelayReasonCode returns the DelayReasonCode field value if set, zero value otherwise.
@@ -400,9 +393,7 @@ func (o TransportEvent) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.References) {
 		toSerialize["references"] = o.References
 	}
-	if !IsNil(o.TransportEventTypeCode) {
-		toSerialize["transportEventTypeCode"] = o.TransportEventTypeCode
-	}
+	toSerialize["transportEventTypeCode"] = o.TransportEventTypeCode
 	if !IsNil(o.DelayReasonCode) {
 		toSerialize["delayReasonCode"] = o.DelayReasonCode
 	}
@@ -425,6 +416,7 @@ func (o *TransportEvent) UnmarshalJSON(data []byte) (err error) {
 		"eventDateTime",
 		"eventCreatedDateTime",
 		"eventClassifierCode",
+		"transportEventTypeCode",
 		"transportCall",
 	}
 

--- a/maersk/model_vessel.go
+++ b/maersk/model_vessel.go
@@ -11,9 +11,7 @@ API version: 1.1.1
 package maersk
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 )
 
 // checks if the Vessel type satisfies the MappedNullable interface at compile time
@@ -22,7 +20,7 @@ var _ MappedNullable = &Vessel{}
 // Vessel struct for Vessel
 type Vessel struct {
 	// The unique reference for a registered Vessel. The reference is the International Maritime Organisation (IMO) number, also sometimes known as the Lloyd's register code, which does not change during the lifetime of the vessel
-	VesselIMONumber string `json:"vesselIMONumber"`
+	VesselIMONumber *string `json:"vesselIMONumber,omitempty"`
 	// The name of the Vessel given by the Vessel Operator and registered with IMO.
 	VesselName *string `json:"vesselName,omitempty"`
 	// The flag of the nation whose laws the vessel is registered under. This is the ISO 3166 two-letter country code
@@ -35,15 +33,12 @@ type Vessel struct {
 	VesselOperatorCarrierCodeListProvider *string `json:"vesselOperatorCarrierCodeListProvider,omitempty"`
 }
 
-type _Vessel Vessel
-
 // NewVessel instantiates a new Vessel object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewVessel(vesselIMONumber string) *Vessel {
+func NewVessel() *Vessel {
 	this := Vessel{}
-	this.VesselIMONumber = vesselIMONumber
 	return &this
 }
 
@@ -55,28 +50,36 @@ func NewVesselWithDefaults() *Vessel {
 	return &this
 }
 
-// GetVesselIMONumber returns the VesselIMONumber field value
+// GetVesselIMONumber returns the VesselIMONumber field value if set, zero value otherwise.
 func (o *Vessel) GetVesselIMONumber() string {
-	if o == nil {
+	if o == nil || IsNil(o.VesselIMONumber) {
 		var ret string
 		return ret
 	}
-
-	return o.VesselIMONumber
+	return *o.VesselIMONumber
 }
 
-// GetVesselIMONumberOk returns a tuple with the VesselIMONumber field value
+// GetVesselIMONumberOk returns a tuple with the VesselIMONumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Vessel) GetVesselIMONumberOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.VesselIMONumber) {
 		return nil, false
 	}
-	return &o.VesselIMONumber, true
+	return o.VesselIMONumber, true
 }
 
-// SetVesselIMONumber sets field value
+// HasVesselIMONumber returns a boolean if a field has been set.
+func (o *Vessel) HasVesselIMONumber() bool {
+	if o != nil && !IsNil(o.VesselIMONumber) {
+		return true
+	}
+
+	return false
+}
+
+// SetVesselIMONumber gets a reference to the given string and assigns it to the VesselIMONumber field.
 func (o *Vessel) SetVesselIMONumber(v string) {
-	o.VesselIMONumber = v
+	o.VesselIMONumber = &v
 }
 
 // GetVesselName returns the VesselName field value if set, zero value otherwise.
@@ -249,7 +252,9 @@ func (o Vessel) MarshalJSON() ([]byte, error) {
 
 func (o Vessel) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["vesselIMONumber"] = o.VesselIMONumber
+	if !IsNil(o.VesselIMONumber) {
+		toSerialize["vesselIMONumber"] = o.VesselIMONumber
+	}
 	if !IsNil(o.VesselName) {
 		toSerialize["vesselName"] = o.VesselName
 	}
@@ -266,43 +271,6 @@ func (o Vessel) ToMap() (map[string]interface{}, error) {
 		toSerialize["vesselOperatorCarrierCodeListProvider"] = o.VesselOperatorCarrierCodeListProvider
 	}
 	return toSerialize, nil
-}
-
-func (o *Vessel) UnmarshalJSON(data []byte) (err error) {
-	// This validates that all required properties are included in the JSON object
-	// by unmarshalling the object into a generic map with string keys and checking
-	// that every required field exists as a key in the generic map.
-	requiredProperties := []string{
-		"vesselIMONumber",
-	}
-
-	allProperties := make(map[string]interface{})
-
-	err = json.Unmarshal(data, &allProperties)
-
-	if err != nil {
-		return err
-	}
-
-	for _, requiredProperty := range requiredProperties {
-		if _, exists := allProperties[requiredProperty]; !exists {
-			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-
-	varVessel := _Vessel{}
-
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varVessel)
-
-	if err != nil {
-		return err
-	}
-
-	*o = Vessel(varVessel)
-
-	return err
 }
 
 type NullableVessel struct {


### PR DESCRIPTION
- remove `required: VesselIMONumber` in `Vessel`, this was correct according to the DCSA specs but Maersk returned a lot of payload without it...
- fix typo `transportEventType` -> `transportEventTypeCode` in the `required` fields of `TransportEvent` (this didn't create any issues)